### PR TITLE
Re-rendered Buttons on Next Click

### DIFF
--- a/src/components/ButtonAnswer.vue
+++ b/src/components/ButtonAnswer.vue
@@ -12,10 +12,10 @@
     name: "ButtonAnswer",
     data() {
       return{
-        disabledBtn: "w-full border border-gray-300 bg-gray-300 rounded-md py-2 mb-3 text-white cursor-none",
+        disabledBtn: "w-full border border-gray-300 bg-gray-300 rounded-md py-2 mb-3 text-white cursor-default",
         normalBtn: "w-full border border-gray-300 rounded-md py-2 mb-3 text-gray-600 hover:border-yellow-500 cursor-pointer",
-        correctBtn: "w-full border border-green-500 bg-green-100 text-green-600  rounded-md py-2 mb-3 cursor-none",
-        wrongBtn: "w-full border border-red-500 bg-red-200 text-red-500  rounded-md py-2 mb-3 cursor-none",
+        correctBtn: "w-full border border-green-500 bg-green-100 text-green-600  rounded-md py-2 mb-3 cursor-default",
+        wrongBtn: "w-full border border-red-500 bg-red-200 text-red-500  rounded-md py-2 mb-3 cursor-default",
         next: true,
       }
     },

--- a/src/components/QuizCard.vue
+++ b/src/components/QuizCard.vue
@@ -3,10 +3,10 @@
   <div class="bg-white rounded-lg p-8 shadow-xl">
     <p class="text-gray-400">Question {{ question_index + 1 }}/10</p>
     <p class="text-gray-600 text-lg font-semibold text-center my-8">{{ quiz_details[question_index].question }}</p>
-    <ButtonAnswer :choice="this.choices[0]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext" />
-    <ButtonAnswer :choice="this.choices[1]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext"/>
-    <ButtonAnswer :choice="this.choices[2]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext"/>
-    <ButtonAnswer :choice="this.choices[3]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext"/>
+    <ButtonAnswer :key="this.btnKey" :choice="this.choices[0]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext" />
+    <ButtonAnswer :key="this.btnKey" :choice="this.choices[1]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext"/>
+    <ButtonAnswer :key="this.btnKey" :choice="this.choices[2]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext"/>
+    <ButtonAnswer :key="this.btnKey" :choice="this.choices[3]" :isDisabled="this.isDisabled" :correct_ans="this.quiz_details[this.question_index].correct_answer" @add-score-and-index="addScoreAndIndex" @disable-btns="disableBtns" @set-isNext-false="setIsNextFalse" :isNext="this.isNext"/>
     
     <!-- <p v-if="this.isDisabled" class="text-sm text-gray-600 text-center mb-2">Correct Answer: {{ quiz_details[question_index].correct_answer }}</p> -->
     
@@ -38,6 +38,7 @@ import ButtonAnswer from './ButtonAnswer.vue';
     },
     data() {
       return {
+        btnKey: 0,
         isDisabled: false,
         isNext: false,
       }
@@ -76,6 +77,7 @@ import ButtonAnswer from './ButtonAnswer.vue';
           //disable to false
           this.isDisabled = false;
           this.isNext = true;
+          this.btnKey=!this.btnKey;
           this.$emit('increase-index')
         },
         setIsNextFalse(){


### PR DESCRIPTION
Re-rendered the ButtonAnswer component when the Next button is clicked. This satisfies the problem where buttons retain their previous state of being clicked thus upon clicking all the buttons, it will all show as incorrect answer. Adding a key prop and a btnKey variable allowed the component to unmount and mount again which also forces them to forget those previous states.

Additional Commit:

- Changed `cursor-none` to `cursor-pointer` for better UX.